### PR TITLE
Update version to 0.9.13

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -15,5 +15,5 @@ if errorlevel 1 exit 1
 cmake --build . --config Release --target install
 if errorlevel 1 exit 1
 
-ctest --output-on-failure
+ctest --output-on-failure 
 if errorlevel 1 exit 1

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,4 @@
+c_stdlib_version: # [win]
+  - 2022.12       # [win]
+c_compiler:       # [win]
+  - vs2022        # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 80b7c6087b0af461b4483e4c9483aea2e0dac5d9fb2289b057159ea6032409e1
 
 build:
-  number: 1
+  number: 0
   run_exports:
     - {{ pin_subpackage("aws-c-cal", max_pin="x.x.x") }}
 
@@ -21,8 +21,8 @@ requirements:
     - cmake >=3.9
     - ninja-base
   host:
-    - aws-c-common 0.12.4
-    - openssl {{ openssl }}  # [linux]
+    - aws-c-common 0.12.6
+    - openssl {{ openssl }} # [linux]
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aws-c-cal" %}
-{% set version = "0.9.2" %}
+{% set version = "0.9.13" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: f9f3bc6a069e2efe25fcdf73e4d2b16b5608c327d2eb57c8f7a8524e9e1fcad0
+  sha256: 80b7c6087b0af461b4483e4c9483aea2e0dac5d9fb2289b057159ea6032409e1
 
 build:
   number: 1


### PR DESCRIPTION
aws-c-cal 0.9.13

**Destination channel:** defaults

### Links

- [PKG-11430](https://anaconda.atlassian.net/browse/PKG-11430) 
- [Upstream repository](https://github.com/awslabs/aws-c-cal)
### Explanation of changes:

- New version number


[PKG-11430]: https://anaconda.atlassian.net/browse/PKG-11430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ