### PR TITLE
aws-c-cal 0.9.14 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - cmake >=3.9
     - ninja-base
   host:
-    - aws-c-common 0.12.6
+    - aws-c-common 0.14.0
     - openssl {{ openssl }} # [linux]
 
 test:
@@ -30,7 +30,7 @@ test:
     # https://discourse.cmake.org/t/questions-about-find-package-cli-msvc/6194
     - {{ compiler('c') }}
     - cmake
-    - ninja
+    - ninja-base
     - pkg-config
   files:
     - cmake_test/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "aws-c-cal" %}
-{% set version = "0.9.13" %}
+{% set version = "0.9.14" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
   url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 80b7c6087b0af461b4483e4c9483aea2e0dac5d9fb2289b057159ea6032409e1
+  sha256: 0e96e0067fa921768e07b5b4ebad82011ccf474903e9286419ef428d68f317ea
 
 build:
   number: 0


### PR DESCRIPTION
aws-c-cal 0.9.14 

**Destination channel:** Defaults

### Links

- [PKG-15438]
- dev_url:        https://github.com/awslabs/aws-c-cal/tree/v0.9.14
- conda_forge:    https://github.com/conda-forge/aws-c-cal-feedstock
- pypi:           None
- pypi inspector: None

### Explanation of changes:

- new version number


[PKG-15438]: https://anaconda.atlassian.net/browse/PKG-15438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ